### PR TITLE
Fix support for English perceptron tagger

### DIFF
--- a/modes.xml
+++ b/modes.xml
@@ -13,7 +13,7 @@
       <program name="cg-proc -w">
         <file name="eng-deu.rlx.bin"/>
       </program>
-      <program name="apertium-tagger -g $2">
+      <program name="apertium-tagger -gx">
         <file name="eng-deu.prob"/>
       </program>
       <program name="apertium-pretransfer"/>
@@ -55,7 +55,7 @@
       <program name="cg-proc -w">
         <file name="eng-deu.rlx.bin"/>
       </program>
-      <program name="apertium-tagger -g $2">
+      <program name="apertium-tagger -gx">
         <file name="eng-deu.prob"/>
       </program>
       <program name="apertium-pretransfer"/>
@@ -110,7 +110,7 @@
       <program name="cg-proc -w">
         <file name="eng-deu.rlx.bin"/>
       </program>
-      <program name="apertium-tagger -g $2">
+      <program name="apertium-tagger -gx">
         <file name="eng-deu.prob"/>
       </program>
     </pipeline>
@@ -126,7 +126,7 @@
       <program name="cg-proc -w">
         <file name="eng-deu.rlx.bin"/>
       </program>
-      <program name="apertium-tagger -g $2">
+      <program name="apertium-tagger -gx">
         <file name="eng-deu.prob"/>
       </program>
       <program name="apertium-pretransfer"/>
@@ -143,7 +143,7 @@
       <program name="cg-proc -w">
         <file name="eng-deu.rlx.bin"/>
       </program>
-      <program name="apertium-tagger -g $2">
+      <program name="apertium-tagger -gx">
         <file name="eng-deu.prob"/>
       </program>
       <program name="apertium-pretransfer"/>
@@ -163,7 +163,7 @@
       <program name="cg-proc -w">
         <file name="eng-deu.rlx.bin"/>
       </program>
-      <program name="apertium-tagger -g $2">
+      <program name="apertium-tagger -gx">
         <file name="eng-deu.prob"/>
       </program>
       <program name="apertium-pretransfer"/>
@@ -186,7 +186,7 @@
       <program name="cg-proc -w">
         <file name="eng-deu.rlx.bin"/>
       </program>
-      <program name="apertium-tagger -g $2">
+      <program name="apertium-tagger -gx">
         <file name="eng-deu.prob"/>
       </program>
       <program name="apertium-pretransfer"/>
@@ -213,7 +213,7 @@
       <program name="cg-proc -w">
         <file name="eng-deu.rlx.bin"/>
       </program>
-      <program name="apertium-tagger -g $2">
+      <program name="apertium-tagger -gx">
         <file name="eng-deu.prob"/>
       </program>
       <program name="apertium-pretransfer"/>
@@ -244,7 +244,7 @@
       <program name="cg-proc -w">
         <file name="eng-deu.rlx.bin"/>
       </program>
-      <program name="apertium-tagger -g $2">
+      <program name="apertium-tagger -gx">
         <file name="eng-deu.prob"/>
       </program>
       <program name="apertium-pretransfer"/>


### PR DESCRIPTION
This adds a flag to modes.xml which is necessary to make the English perceptron tagger work.